### PR TITLE
Add Support for py<3.6 (string literal)

### DIFF
--- a/blackmagic/dbgprint.py
+++ b/blackmagic/dbgprint.py
@@ -8,4 +8,7 @@ def dbgprint(*args):
     syntax_tree = ast.parse(caller.line)
     names = syntax_tree.body[0].value.args
     for name in names:
-        print(f'{name.id} = {args.pop()}')
+        try:
+            eval("print(f'{name.id} = {args.pop()}')")
+        except SyntaxError:
+            print('{} = {}'.format(name.id, args.pop()))

--- a/blackmagic/meta.py
+++ b/blackmagic/meta.py
@@ -20,7 +20,10 @@ class ProfileMeta(type):
                     start_ms = time()
                     returned_value = value(*args, **kwargs)
                     end_ms = time()
-                    print(f"{cls_name}::{name} elapsed {end_ms - start_ms}ms")
+                    try:
+                        eval("print(f'{cls_name}::{name} elapsed {end_ms - start_ms}ms')")
+                    except SyntaxError:
+                        print("{}::{} elapsed {}ms".format(cls_name, name, (end_ms - start_ms)))
                     return returned_value
                 attrs[name] = wrapper
         return super().__new__(mcs, name, bases, attrs)


### PR DESCRIPTION
Python String literal supports for python < 3.6

Tested with cpython 3.5